### PR TITLE
feat: ajouter la copie des instructions personnalisées dans le dossier

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Build project
         run: npm run build
 
+      - name: Copy custom-instructions to dist
+        run: cp -R custom-instructions dist/
+
       - name: Setup Pages
         uses: actions/configure-pages@v4
 


### PR DESCRIPTION
This pull request includes changes to streamline the deployment process and update the file loading mechanism in the `WorkspaceSection` component. The most important changes are as follows:

### Deployment Process Improvements:
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R33-R35): Added a step to copy `custom-instructions` to the `dist` directory before setting up Pages.

### WorkspaceSection Component Updates:
* [`src/components/WorkspaceSection.tsx`](diffhunk://#diff-c89ae686cc497296900e6af23f5152b9284c7ffb490a570d040af3214a0e13edL4): Removed the `Octokit` import as it is no longer needed.
* [`src/components/WorkspaceSection.tsx`](diffhunk://#diff-c89ae686cc497296900e6af23f5152b9284c7ffb490a570d040af3214a0e13edL23-R50): Replaced the `loadWorkspaceFiles` function with `loadLocalFiles` to fetch file data from a local JSON file instead of a GitHub repository.
* [`src/components/WorkspaceSection.tsx`](diffhunk://#diff-c89ae686cc497296900e6af23f5152b9284c7ffb490a570d040af3214a0e13edL104-R79): Updated the file reading logic to fetch file contents from the local `custom-instructions` directory.…r de distribution et modifier le chargement des fichiers pour utiliser une liste locale